### PR TITLE
wwtd: docker-ise

### DIFF
--- a/.elasticbeanstalk/config.yml
+++ b/.elasticbeanstalk/config.yml
@@ -1,0 +1,11 @@
+branch-defaults:
+  docker:
+    environment: wwtd-prod
+    group_suffix: null
+global:
+  application_name: wwtd
+  default_ec2_keyname: wwtd
+  default_platform: Docker 1.11.2
+  default_region: us-east-1
+  profile: bf-openlab
+  sc: git

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.pyc
 
-app_config.py
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+from python:3.5
+
+RUN mkdir /app
+COPY . /app
+WORKDIR /app
+RUN pip install -r requirements.txt
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/app.py
+++ b/app.py
@@ -136,4 +136,4 @@ def disapprove(story_id):
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=True, host='0.0.0.0')

--- a/story_collector/app_config.py
+++ b/story_collector/app_config.py
@@ -6,4 +6,4 @@ DB_NAME = 'story_collector'
 ADMIN_USER = 'admin'
 ADMIN_PASS = 'something-secret'
 
-USE_FAKE_DATA = False # set this to True to use dummy data instead of db
+USE_FAKE_DATA = True # set this to True to use dummy data instead of db


### PR DESCRIPTION
@cathydeng @amandabee 

I've added a `Dockerfile` - at this point consider the app "dockerised".

Once you have the `docker` daemon installed on your mac - you can do `docker build .` and `docker run -p 5000:5000 <container ID from build command>`

This will significantly make dev faster and sets us up to run this in the mythical creature called `rig`

Couple of things to note - if you can change the `app_config.py` file to read from environment variables - you can tack on things like `-e DB_HOST=foo` to the `docker run` command. That way you aren't storing sensitive info in the repo.

Give this a shot locally and let me know. And we can take it from there. 